### PR TITLE
A typo in the text on the main page

### DIFF
--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -67,7 +67,7 @@
   "elementalReactionsExplained": "Комбинации разных элементов дают разные элементарные реакции",
   "elementalResonances": "Элементальный резонанс",
   "elementalResonancesExplained": "Наличие в вашей отряде персонажей таких типов дает соответствующие эффекты",
-  "todayAscensionMaterials": "Ежедневный збор",
+  "todayAscensionMaterials": "Ежедневный сбор",
   "seeAll": "Показать все",
   "characters": "Персонажи",
   "weapons": "Оружие",


### PR DESCRIPTION
A typo in the text on the main page. "збор" is wrong